### PR TITLE
Added rust version to intro page; added missing command prompt to Linux/macOS command; fixed incorrect reference to PATH

### DIFF
--- a/src/ch01-01-installation.md
+++ b/src/ch01-01-installation.md
@@ -89,7 +89,7 @@ rustc x.y.z (abcabcabc yyyy-mm-dd)
 ```
 
 If you see this information, you have installed Rust successfully! If you don’t
-see this information, check that Rust is in your `%PATH%`
+see this information, check that Rust is in your `PATH`
 system variable as follows.
 
 In Windows CMD, use:
@@ -107,7 +107,7 @@ In PowerShell, use:
 In Linux and macOS, use:
 
 ```console
-echo $PATH
+$ echo $PATH
 ```
 
 If that’s all correct and Rust still isn’t working, there are a number of

--- a/src/title-page.md
+++ b/src/title-page.md
@@ -6,7 +6,7 @@
 
 This version of the text assumes you’re using Rust 1.62 (released 2022-06-30)
 or later. See the [“Installation” section of Chapter 1][install]<!-- ignore -->
-to install or update Rust.
+to install or update Rust. Run `rustc --version` to see your Rust version.
 
 The HTML format is available online at
 [https://doc.rust-lang.org/stable/book/](https://doc.rust-lang.org/stable/book/)


### PR DESCRIPTION
If the docs tell people that a specific version of Rust is required, give them the command to show their Rust version.

Include a command prompt in all commands.

%PATH% is a Windows construct and shouldn't be used generically to describe the PATH environment variable, which you call a system variable.