### PR TITLE
Update code snipped for `std::thread::spawn`

### DIFF
--- a/src/ch20-02-multithreaded.md
+++ b/src/ch20-02-multithreaded.md
@@ -236,8 +236,7 @@ has on its parameter. The documentation shows us the following:
 ```rust,ignore
 pub fn spawn<F, T>(f: F) -> JoinHandle<T>
     where
-        F: FnOnce() -> T,
-        F: Send + 'static,
+        F: FnOnce() -> T + Send + 'static,
         T: Send + 'static,
 ```
 


### PR DESCRIPTION
The link: https://doc.rust-lang.org/stable/std/thread/fn.spawn.html

I'm not sure why the documentation is not linked from the book, maybe there's a reason for that.