### PR TITLE
Fix example so it compiles

### DIFF
--- a/src/ch04-03-fixing-ownership-errors.md
+++ b/src/ch04-03-fixing-ownership-errors.md
@@ -124,7 +124,7 @@ By cloning `name`, we are allowed to mutate the local copy of the vector. Howeve
 
 ```rust,ignore
 fn stringify_name_with_title(name: &Vec<String>) -> String {
-    let full = name.join(" ");
+    let mut full = name.join(" ");
     full.push_str(" Esq.");
     full
 }


### PR DESCRIPTION
Can't `push_str` on immutable variable. The example doesn't compile. I believe just adding `mut` to:

```rust
let full = name.join(" ");
```

Fixes the issue.