### PR TITLE
Make X var mutable in Control Flow Quiz.

### DIFF
--- a/quizzes/ch03-05-control-flow-sec1-if.toml
+++ b/quizzes/ch03-05-control-flow-sec1-if.toml
@@ -11,7 +11,7 @@ let x = if cond { 1 } else { 2 };
 
 Snippet 2:
 ```
-let x;
+let mut x = 0;
 if cond {
   x = 1;
 } else {


### PR DESCRIPTION
The first question in the first quiz of the Control Flow page does not compile, since the variable is not mutable and there is no type annotation or value to infer the type. I added mutability to the variable and defined it to 0.