### PR TITLE
minor typo fix: Update ch05-01-defining-structs.md

### DIFF
--- a/src/ch05-01-defining-structs.md
+++ b/src/ch05-01-defining-structs.md
@@ -326,7 +326,7 @@ implement them on any type, including unit-like structs.
 ### Borrowing Fields of a Struct
 
 Similar to our discussion in ["Different Tuple Fields"][differentfields], Rust's borrow checker will track ownership permissions
-at the both the struct-level and field-level. For example, if we borrow a field `x` of a `Point` structure, then both `p` and `p.x` temporarily lose their permissions (but not `p.y`):
+at both the struct-level and field-level. For example, if we borrow a field `x` of a `Point` structure, then both `p` and `p.x` temporarily lose their permissions (but not `p.y`):
 
 ```aquascope,permissions,stepper,boundaries
 #fn main() {


### PR DESCRIPTION
typo fixed. ("the both the" changed to "both the")

PS: I am really enjoying reading this version of the Rust book. I love the code animations of R,W,O for the borrow checker.