### PR TITLE
Doc: added two words to make complete sense

### DIFF
--- a/src/ch05-03-method-syntax.md
+++ b/src/ch05-03-method-syntax.md
@@ -143,7 +143,7 @@ parameters in functions.
 
 All functions defined within an `impl` block are called *associated functions*
 because they’re associated with the type named after the `impl`. We can define
-associated functions that don’t have `self` as their first parameter (and thus
+associated functions as functions that don’t have `self` as their first parameter (and thus
 are not methods) because they don’t need an instance of the type to work with.
 We’ve already used one function like this: the `String::from` function that’s
 defined on the `String` type.


### PR DESCRIPTION
From line 145  to 146, I think the definition of Associated function doesn't make complete sense without the addition I made to it.