### PR TITLE
Fix non existing anchor in link

### DIFF
--- a/src/ch05-01-defining-structs.md
+++ b/src/ch05-01-defining-structs.md
@@ -387,4 +387,4 @@ add `> ` before every line -->
 [tuples]: ch03-02-data-types.html#the-tuple-type
 [move]: ch04-01-what-is-ownership.html
 [copy]: ch04-03-fixing-ownership-errors.html#fixing-an-unsafe-program-copying-vs-moving-out-of-a-vector
-[differentfields]: ch04-03-fixing-ownership-errors.html#fixing-a-safe-program-different-tuple-fields
+[differentfields]: ch04-03-fixing-ownership-errors.html#fixing-a-safe-program-mutating-different-tuple-fields


### PR DESCRIPTION

The problem is that in https://rust-book.cs.brown.edu/ch05-01-defining-structs.html#borrowing-fields-of-a-structthe link to "Different Tuple Fields" takes you to the beginning of the chapter instead of the appropriate section.

I haven't used mdbook before so I'm not sure if this is the way to fix it. Let me know if there's a better way.