### PR TITLE
Refutability 18-02 example fix

### DIFF
--- a/src/ch18-02-refutability.md
+++ b/src/ch18-02-refutability.md
@@ -9,7 +9,7 @@ to match. Patterns that can fail to match for some possible value are
 <!-- BEGIN INTERVENTION: 3c29eb2d-cbe9-4a2c-99b8-aa5c6467c8b4 -->
 * In the expression `if let Some(x) = a_value`, then `Some(x)` is refutable. If the value in the `a_value` variable is `None` rather than
 `Some`, the `Some(x)` pattern will not match. 
-* In the expression `let &[x, ..] = a_slice`, then `&[x, ..]` is refutable. If the value in the `a_slice` variable has zero elements, the `&[x, ..]` pattern will not match.
+* In the expression `if let &[x, ..] = a_slice`, then `&[x, ..]` is refutable. If the value in the `a_slice` variable has zero elements, the `&[x, ..]` pattern will not match.
 <!-- END INTERVENTION: 3c29eb2d-cbe9-4a2c-99b8-aa5c6467c8b4 -->
 
 Function parameters, `let` statements, and `for` loops can only accept


### PR DESCRIPTION
The old example is wrong. It would be refutable if the expression becomes `if let ...`, but it in the old case, with just a `let ...` it is irrefutable. That this example is refutable is contradicted by the next paragraph. It also gives a compiler error when given by itself (refutable pattern in local binding. pattern `&[]` not covered. note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant. The error specifically points to this same chapter in docs.rust-lang.org, which does not include these examples.