### PR TITLE
minor update ~/quizzes/ch18-03-pattern-syntax.toml question 2 context

### DIFF
--- a/quizzes/ch18-03-pattern-syntax.toml
+++ b/quizzes/ch18-03-pattern-syntax.toml
@@ -40,7 +40,7 @@ prompt.distractors = [
     "`(_, n)`"
 ]
 context = """ 
-The pattern `(_, n)` is not valid because `a` is an array of tuples, not a tuple itself.
+The pattern `(_, n)` is not valid because `a` is a length one array of tuples, not a tuple itself.
 """
 
 [[questions]]


### PR DESCRIPTION
_Note: I'm aware that this does not meet the [CONTRIBUTING ](https://github.com/cognitive-engineering-lab/rust-book/blob/54ed52423cefa10b83eff10e1ff3cba71e42eb9f/CONTRIBUTING.md)guidelines since this isn't to the text of the book in `src/`_
_Other note: I really appreciate this project going beyond what the community has already built within the rust-book. Thanks!_

---
Proposing this minor change in the hint's verbiage for quiz 18-03 question 2 as not all other languages implement type for both element type _and length_ for arrays. This edit makes indication to the array type specifying length.

Would this change be _too_ helpful as a hint? It might be as I'm new and figured it out.