### PR TITLE
Typo fix in ch03-05-control-flow-sec2-loops.toml

### DIFF
--- a/quizzes/ch03-05-control-flow-sec2-loops.toml
+++ b/quizzes/ch03-05-control-flow-sec2-loops.toml
@@ -32,7 +32,7 @@ id = "46a52842-d4eb-4dc9-8885-f31a2f2f59b4"
 type = "Tracing"
 prompt.program = """
 fn main() {
-    let a = [5; 10];
+    let a = [5, 10];
     let mut sum = 0;
     for x in a {
         sum += x;


### PR DESCRIPTION
Should be a comma rather than a semicolon, to separate array elements