### PR TITLE
Fix broken link to Copying vs. Moving Out of a Collection in ch05-01

### DIFF
--- a/src/ch05-01-defining-structs.md
+++ b/src/ch05-01-defining-structs.md
@@ -196,7 +196,7 @@ longer use `user1` after creating `user2` because the `String` in the
 `active` and `sign_in_count` values from `user1`, then `user1` would still be
 valid after creating `user2`. The types of `active` and `sign_in_count` are
 types that implement the `Copy` trait, so the behavior we discussed in the
-[“Copying vs. Moving Out of a Vector”][copy]<!-- ignore --> section would apply.
+[“Copying vs. Moving Out of a Collection”][copy]<!-- ignore --> section would apply.
 
 ### Using Tuple Structs Without Named Fields to Create Different Types
 
@@ -398,5 +398,5 @@ add `> ` before every line -->
 
 [tuples]: ch03-02-data-types.html#the-tuple-type
 [move]: ch04-01-what-is-ownership.html
-[copy]: ch04-03-fixing-ownership-errors.html#fixing-an-unsafe-program-copying-vs-moving-out-of-a-vector
+[copy]: ch04-03-fixing-ownership-errors.html#fixing-an-unsafe-program-copying-vs-moving-out-of-a-collection
 [differentfields]: ch04-03-fixing-ownership-errors.html#fixing-a-safe-program-mutating-different-tuple-fields


### PR DESCRIPTION
Leftover from 08c63f2 ([diff](https://github.com/cognitive-engineering-lab/rust-book/commit/08c63f2df5855d5f88666b40a21bd4c7fda13f01#diff-8c830352f965caab3816447cd5084a67d13142c8a702d728bc412fc075601980R119)) & b0ffa34 ([diff](https://github.com/cognitive-engineering-lab/rust-book/commit/b0ffa3494cd61f407b316863ac892e2784adbb38#diff-8c830352f965caab3816447cd5084a67d13142c8a702d728bc412fc075601980R200))