### PR TITLE
Darkened feedback component, modal overlay color

### DIFF
--- a/js-extensions/packages/feedback/feedback.scss
+++ b/js-extensions/packages/feedback/feedback.scss
@@ -117,9 +117,10 @@
   border-right: 1px solid var(--popper-bg-hover);
 }
 
+
 .ReactModal__Overlay {
   z-index: 101; // must be >= #menu-bar z-index
-
+  background-color: rgba($color: rgb(57, 57, 57), $alpha: 0.1);
   textarea {
     font-family: 'Open Sans', sans-serif;
     min-width: 250px;

--- a/js-extensions/packages/feedback/lib/modal.tsx
+++ b/js-extensions/packages/feedback/lib/modal.tsx
@@ -12,9 +12,13 @@ const modalStyles = {
     right: "auto",
     bottom: "auto",
     marginRight: "-50%",
-    transform: "translate(-50%, -50%)",
+    transform: "translate(-50%, -50%)"
+  },
+  overlay: {
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
   },
 };
+
 
 type FeedbackModalProps = {
   range: Range;
@@ -39,7 +43,9 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({ range, highlighter, close
   };
 
   return (
-    <Modal style={modalStyles} contentLabel="Feedback Modal" onRequestClose={closeModal} isOpen>
+    <Modal style={modalStyles} contentLabel="Feedback Modal" 
+    
+    onRequestClose={closeModal} isOpen>
       <textarea autoFocus ref={feedback} rows={4} placeholder="Your note..." required></textarea>
       <br />
       <button onClick={handleSubmit}>Submit</button>

--- a/js-extensions/pnpm-lock.yaml
+++ b/js-extensions/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -6805,3 +6801,7 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
Darkened the modal overlay, when highlighting so that it doesn't flash bright white background when user is in darker theme modes. 