### PR TITLE
Fix function name mismatch in Intermediates design challenge quiz

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Finally, you need [pnpm](https://pnpm.io/installation).
 If you have [`cargo-make`] installed, then run:
 
 ```bash
-$ cargo make install
+$ cargo make build
 ```
 
 ### Without cargo-make

--- a/js-extensions/packages/feedback/lib/modal.tsx
+++ b/js-extensions/packages/feedback/lib/modal.tsx
@@ -13,7 +13,13 @@ const modalStyles = {
     bottom: "auto",
     marginRight: "-50%",
     transform: "translate(-50%, -50%)",
+    background: "var(--theme-popup-bg)",    
+    borderColor: "var(--theme-popup-border)",
+    color: "var(--fg)",
   },
+  overlay: {
+    backgroundColor: "color-mix(in srgb, var(--bg) 80%, transparent)"
+  }
 };
 
 type FeedbackModalProps = {

--- a/quizzes/ch17-05-design-challenge-intermediates.toml
+++ b/quizzes/ch17-05-design-challenge-intermediates.toml
@@ -2,7 +2,7 @@
 q = """
 **Context:** You are designing a serialization library that converts Rust data types into formats like JSON.
 
-**Functionality:** A `Serialize` trait that can be implemented by serializable types, and a `to_string` function that converts serializable types into JSON.
+**Functionality:** A `Serialize` trait that can be implemented by serializable types, and a `to_json` function that converts serializable types into JSON.
 
 **Designs:** Below are several proposed designs to implement the functionality.
 
@@ -21,7 +21,7 @@ fn value_to_json(value: Value) -> String {
 	/* .. */
 }
 
-pub fn to_json(data: impl Serialize) -> String { 
+pub fn to_json(data: impl Serialize) -> String {
     let value = data.serialize();
     value_to_json(value)
 }
@@ -42,7 +42,7 @@ impl Serializer for JsonSerializer {
 	/* .. */
 }
 
-pub fn to_json(data: impl Serialize) -> String { 
+pub fn to_json(data: impl Serialize) -> String {
 	let mut serializer = JsonSerializer { buffer: String::new() };
 	data.serialize(&mut serializer);
 	serializer.buffer
@@ -100,7 +100,7 @@ prompt.distractors = ["2"]
 prompt.sortAnswers = true
 answer.answer = ["1"]
 context = """
-With Option 1, there is only a single instantiation of `Serialize` that converts a type `T` into a `Value`. Because Option 2 is generic over serializers `S`, 
+With Option 1, there is only a single instantiation of `Serialize` that converts a type `T` into a `Value`. Because Option 2 is generic over serializers `S`,
 then every time `T::serialize` is called with a new `S`, the Rust compiler will monomorphize a new instance of `T::serialize` which would increase the size of
 the binary by comparison to Option 1.
 """

--- a/src/ch03-04-comments.md
+++ b/src/ch03-04-comments.md
@@ -21,6 +21,14 @@ single line, you’ll need to include `//` on each line, like this:
 // explain what’s going on.
 ```
 
+Or you can use the multiline comment syntax with `/*` and `*/`:
+
+```rust
+/* So we’re doing something complicated here, long enough that we need
+   multiple lines of comments to do it! Whew! Hopefully, this comment will
+   explain what’s going on. */
+```
+
 Comments can also be placed at the end of lines containing code:
 
 <span class="filename">Filename: src/main.rs</span>

--- a/src/ch04-03-fixing-ownership-errors.md
+++ b/src/ch04-03-fixing-ownership-errors.md
@@ -138,7 +138,7 @@ fn stringify_name_with_title(name: &Vec<String>) -> String {
 }
 ```
 
-This solution works becauase [`slice::join`] already copies the data in `name` into the string `full`.
+This solution works because [`slice::join`] already copies the data in `name` into the string `full`.
 
 In general, writing Rust functions is a careful balance of asking for the *right* level of permissions. For this example, it's most idiomatic to only expect the read permission on `name`.
 

--- a/src/ch18-03-pattern-syntax.md
+++ b/src/ch18-03-pattern-syntax.md
@@ -477,8 +477,9 @@ second arm doesn’t have a match guard and therefore matches any `Some` variant
 
 There is no way to express the `if x % 2 == 0` condition within a pattern, so
 the match guard gives us the ability to express this logic. The downside of
-this additional expressiveness is that the compiler doesn't try to check for
-exhaustiveness when match guard expressions are involved.
+this additional expressiveness is that arms with match guards don't "count" towards
+exhaustiveness. So even if we added `Some(x) if x % 2 == 1` as an additional arm, we would still
+need the un-guarded `Some(x)` arm.
 
 In Listing 18-11, we mentioned that we could use match guards to solve our
 pattern-shadowing problem. Recall that we created a new variable inside the

--- a/src/ch19-05-advanced-functions-and-closures.md
+++ b/src/ch19-05-advanced-functions-and-closures.md
@@ -93,8 +93,7 @@ Closures are represented by traits, which means you can’t return closures
 directly. In most cases where you might want to return a trait, you can instead
 use the concrete type that implements the trait as the return type of the
 function. However, you can’t do that with closures because they don’t have a
-concrete type that is returnable; you’re not allowed to use the function
-pointer `fn` as a return type, for example.
+concrete type that is returnable.
 
 The following code tries to return a closure directly, but it won’t compile:
 

--- a/src/experiment-intro.md
+++ b/src/experiment-intro.md
@@ -50,4 +50,4 @@ _Interested in participating in other experiments about making Rust easier to le
 
 ## 4. Acknowledgments
 
-Niko Matsakis and Amazon Web Services provided funding for this experiment. Carol Nichols and the Rust Foundation helped publicize the experiment. TRPL is the product of many peoples' hard work before we started this experiment.
+Niko Matsakis and Amazon Web Services provided funding for this experiment. Carol Nichols and the Rust Foundation helped publicize the experiment. TRPL is the product of many people's hard work before we started this experiment.


### PR DESCRIPTION
Fix `to_json`being referenced as `to_string` in the functionality description of the Intermediates design challenge in chapter 17