### PR TITLE
fix typo in code snippet

### DIFF
--- a/quizzes/ch17-05-design-challenge-references.toml
+++ b/quizzes/ch17-05-design-challenge-references.toml
@@ -75,13 +75,13 @@ context = """
 ```
 let asset = {
     let manager = get_manager();
-    manager.load("some/path");
+    manager.load("some/path")
 };
 process_asset(asset);
 let another_asset = {
     let manager = get_manager();
     manager.load("another/path")
-}
+};
 ```
 
 In this case, the lifetime of the value returned by `load` must not be tied to the lifetime of the `AssetManager`. Options 1 and 2


### PR DESCRIPTION
The definition of `asset` returns `()`, which doesn't seem to be intended. The definition of `another_asset` would result in a syntax error from the missing semicolon.