### PR TITLE
feat: docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,65 @@
+FROM ubuntu:24.04
+
+ENV RUST_VERSION 1.74
+ENV MDBOOK_QUIZ_VERSION 0.3.3
+ENV MDBOOK_VERSION 0.4.34
+ENV AQUASCOPE_VERSION 0.3.1
+ENV AQUASCOPE_TOOLCHAIN nightly-2023-08-25
+ENV PATH "$PATH:/home/ubuntu/bin:/home/ubuntu/.volta/bin:/home/ubuntu/.cargo/bin"
+
+COPY . /opt/rust-book
+
+RUN echo \
+  && apt-get update \
+  && apt install -y rustup curl wget gcc git nginx \
+  && chown -R ubuntu /opt/rust-book
+
+USER ubuntu
+WORKDIR /home/ubuntu
+
+RUN echo \
+  && rustup set profile minimal \
+  && rustup toolchain install ${RUST_VERSION} -c rust-docs \
+  && rustup default ${RUST_VERSION} \
+  && rustup toolchain install ${AQUASCOPE_TOOLCHAIN} -c rust-src rustc-dev llvm-tools-preview miri \
+  && cargo +${AQUASCOPE_TOOLCHAIN} miri setup \
+  && export LD_LIBRARY_PATH="$($(rustup which --toolchain ${AQUASCOPE_TOOLCHAIN} rustc) --print target-libdir)"
+
+RUN echo \
+  && mkdir -p bin \
+  && curl -sSL https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin \
+  && curl -sSL https://github.com/cognitive-engineering-lab/mdbook-quiz/releases/download/v${MDBOOK_QUIZ_VERSION}/mdbook-quiz_x86_64-unknown-linux-gnu_full.tar.gz | tar -xz --directory=bin \
+  && curl -sSL https://github.com/cognitive-engineering-lab/aquascope/releases/download/v${AQUASCOPE_VERSION}/aquascope-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin \
+  && rustup --version \
+  && rustc -Vv \
+  && mdbook --version \
+  && mdbook-quiz --version \
+  && mdbook-aquascope --version
+
+RUN echo \
+  && curl -sL https://get.volta.sh | bash \
+  && volta install node@18 pnpm
+
+WORKDIR /opt/rust-book/js-extensions
+
+RUN pnpm init-repo
+
+WORKDIR /opt/rust-book
+
+RUN mdbook build
+
+USER root
+
+RUN echo \
+  && cp -a /opt/rust-book/book/* /var/www/html/ \
+  && rm /-rf /opt/rust-book
+
+# Set the proper mimetype on mjs files else the quiz is not loaded properly
+RUN echo \
+  && sed -i -e /}/d /etc/nginx/mime.types \
+  && echo "application/javascript mjs;" >> /etc/nginx/mime.types \
+  && echo '}' >> /etc/nginx/mime.types
+
+WORKDIR /tmp
+
+ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ USER root
 
 RUN echo \
   && cp -a /opt/rust-book/book/* /var/www/html/ \
-  && rm /-rf /opt/rust-book
+  && rm -rf /opt/rust-book
 
 # Set the proper mimetype on mjs files else the quiz is not loaded properly
 RUN echo \

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can now build a portable container with the book inside, handy for situation
 It's recommended to take a shallow clone of this repository when building a Docker container.
 
 ```bash
-git clone git@github.com:cognitive-engineering-lab/rust-book --depth 1
+git clone https://github.com/cognitive-engineering-lab/rust-book.git --depth 1
 ```
 
 Build the container:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,30 @@ See the [releases] to download just the code of all the code listings that appea
 
 [releases]: https://github.com/rust-lang/book/releases
 
+## In-flight entertainment
+
+You can now build a portable container with the book inside, handy for situations where you have limited to no internet access!
+
+It's recommended to take a shallow clone of this repository when building a Docker container.
+
+```bash
+git clone git@github.com:cognitive-engineering-lab/rust-book --depth 1
+```
+
+Build the container:
+
+```bash
+docker build -t rust-book .
+```
+
+And run it:
+
+```
+docker run --rm -it -p 8080:80 rust-book
+```
+
+Now just navigate using your browser of choice to http://localhost:8080 to access the book.
+
 ## Requirements
 
 Building the book requires [mdBook], ideally the same version that


### PR DESCRIPTION
This puts the entire book in a `docker` container, which is useful for those wanting to start their _Rust journey_ in moments of limited to no internet connectivity ✈️ 

It also makes it possible to start learning (with the book) without needing to build this project first, which on my Mac was quite the trouble.

It builds on `amd64`, seems `aarch64` is not possible (yet) as some of the required dependencies are not available in the required target architecture.

Minor note: I'm not using `depot` but `volta` to manage the nodejs stuff, as I found that to be simpler and closer to home.