### PR TITLE
fix typo in ch03-01-sec2 quiz-1

### DIFF
--- a/quizzes/ch03-01-variables-and-mutability-sec2-constants.toml
+++ b/quizzes/ch03-01-variables-and-mutability-sec2-constants.toml
@@ -1,7 +1,7 @@
 [[questions]]
 id = "a48e524e-852c-400c-ae68-5c76a6761596"
 type = "MultipleChoice"
-prompt.prompt = "Which of the following statements is correct about the difference between using `let` and `const` to declare a variable?"
+prompt.prompt = "Which of the following statements is incorrect about the difference between using `let` and `const` to declare a variable?"
 answer.answer = "`const` can be used in the global scope, and `let` can only be used in a function"
 prompt.distractors = [
   "They are just different syntaxes for declaring variables with the same semantics",


### PR DESCRIPTION
"correct" --> "incorrect", ch03-01variables-and-mutability-sec2-constants.toml

![image](https://github.com/user-attachments/assets/432905b1-9538-4c62-8744-0fb2caff049d)
