### PR TITLE
Fix typo in ch17-1 Futures and Async Syntax: "page_url_for" -> "page_title"

### DIFF
--- a/src/ch17-01-futures-and-syntax.md
+++ b/src/ch17-01-futures-and-syntax.md
@@ -123,7 +123,7 @@ Notice that Rust’s `await` keyword goes after the expression you are awaiting,
 not before it. That is, it is a *postfix keyword*. This may be different from
 what you might be used to if you have used async in other languages. Rust chose
 this because it makes chains of methods much nicer to work with. As a result, we
-can change the body of `page_url_for` to chain the `trpl::get` and `text`
+can change the body of `page_title` to chain the `trpl::get` and `text`
 function calls together with `await` between them, as shown in Listing 17-2:
 
 <Listing number="17-2" file-name="src/main.rs" caption="Chaining with the `await` keyword">


### PR DESCRIPTION
I modified ch17-1 to change a reference to the non-existent function `page_url_for `to `page_title`.  I can't see any reference to a function called `page_url_for `anywhere in the repo, and the surrounding text implies that it is talking about the function `page_title`.

I'm sorry if I'm missing something.

Related issue:
https://github.com/cognitive-engineering-lab/rust-book/issues/220