### PR TITLE
Wrong chapter was specified

### DIFF
--- a/src/ch15-01-box.md
+++ b/src/ch15-01-box.md
@@ -23,10 +23,10 @@ time because the data is copied around on the stack. To improve performance in
 this situation, we can store the large amount of data on the heap in a box.
 Then, only the small amount of pointer data is copied around on the stack,
 while the data it references stays in one place on the heap. The third case is
-known as a *trait object*, and Chapter 17 devotes an entire section, [“Using
+known as a *trait object*, and Chapter 18 devotes an entire section, [“Using
 Trait Objects That Allow for Values of Different Types,”][trait-objects]<!--
 ignore --> just to that topic. So what you learn here you’ll apply again in
-Chapter 17!
+Chapter 18!
 
 ### Using a `Box<T>` to Store Data on the Heap
 


### PR DESCRIPTION
I found a bug, where the wrong chapter was specified, the link led to chapter 18, but the text stated it was chapter 17.