### PR TITLE
Fix reference to `Patterns and Matching` chapter using the wrong chapter number

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -614,7 +614,7 @@ fits that arm’s pattern. Rust takes the value given to `match` and looks
 through each arm’s pattern in turn. Patterns and the `match` construct are
 powerful Rust features: they let you express a variety of situations your code
 might encounter and they make sure you handle them all. These features will be
-covered in detail in Chapter 6 and Chapter 18, respectively.
+covered in detail in Chapter 6 and Chapter 19, respectively.
 
 Let’s walk through an example with the `match` expression we use here. Say that
 the user has guessed 50 and the randomly generated secret number this time is


### PR DESCRIPTION
Hi.

Im new to Rust, and i saw chapter 2 of the book saying the following:

> Patterns and the match construct are powerful Rust features: they let you express a variety of situations your code might encounter and they make sure you handle them all. These features will be covered in detail in Chapter 6 and Chapter 18, respectively.

But when i look at the index, i see that Chapter 18 is about OOP, and the one about **Patterns and Matching** is instead Chapter 19, so i figured that it may be an error

![image](https://github.com/user-attachments/assets/74d399f7-fd82-4781-82b0-f90c38da9b25)
