### PR TITLE
fix-ch06-02-match-quiz: Ensure same behavior for all inputs. 

### DIFF
--- a/quizzes/ch06-02-match.toml
+++ b/quizzes/ch06-02-match.toml
@@ -93,7 +93,7 @@ fn decr_twice_v1(n: u32) -> Option<u32> {
   match n {
     0 => None,
     1 => None,
-    n2 => Some(n2 - 2)
+    _ => Some(n - 2)
   }
 }
 


### PR DESCRIPTION
- Updated decr_twice_v1 to use `_` instead of `n2` in the match statement to ensure consistent behavior with decr_twice_v2.
- Fixed typo
- Both functions now correctly handle all inputs in the same way as per the right answer.