### PR TITLE
Update variable numbers in ch15-06 quiz

### DIFF
--- a/quizzes/ch15-06-reference-cycles.toml
+++ b/quizzes/ch15-06-reference-cycles.toml
@@ -5,18 +5,18 @@ prompt.program = """
 use std::rc::Rc;
 fn main() {
     let r1 = Rc::new(0);
-    let r4 = {
+    let r3 = {
         let r2 = Rc::clone(&r1);
         Rc::downgrade(&r2)
     };
-    let r5 = Rc::clone(&r1);
-    let r6 = r4.upgrade();
+    let r4 = Rc::clone(&r1);
+    let r5 = r4.upgrade();
     println!("{} {}", Rc::strong_count(&r1), Rc::weak_count(&r1));
 }
 """
 answer.doesCompile = true
 answer.stdout = "3 1"
 context = """
-The three strong refs are `r1`, `r5`, and `r6`. The one weak ref is `r4`, which is dropped at the end of `main`.
+The three strong refs are `r1`, `r4`, and `r5`. The one weak ref is `r3`, which is dropped at the end of `main`.
 `r2` is dropped at the end of its scope.
 """


### PR DESCRIPTION
Since r3 doesn't exist the following could be changed:
r4 to r3,
r5 to r4,
r6 to r5.