### PR TITLE
Add missing first_or function to ch04-02-references-and-borrowing.md

### DIFF
--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -392,6 +392,13 @@ This snippet introduces a new kind of permission, the flow permission @Perm{flow
 
 Unlike the @Perm{read}@Perm{write}@Perm{own} permissions, @Perm{flow} does not change throughout the body of a function. A reference has the @Perm{flow} permission if it's allowed to be used (that is, to *flow*) in a particular expression. For example, let's say we change `first` to a new function `first_or` that includes a `default` parameter:
 
+```aquascope,permissions,boundaries,showFlows
+fn first_or(strings: &Vec<String>, default: &String) -> &String {
+    let s_ref = &strings[0];
+    s_ref`{}`
+}
+```
+
 This function no longer compiles, because the expressions `&strings[0]` and `default` lack the necessary @Perm{flow} permission to be returned. But why? Rust gives the following error:
 
 ```text


### PR DESCRIPTION
Fixes #262.