### PR TITLE
Update ch06-02-match.md

### DIFF
--- a/src/ch06-02-match.md
+++ b/src/ch06-02-match.md
@@ -6,7 +6,7 @@ Rust has an extremely powerful control flow construct called `match` that
 allows you to compare a value against a series of patterns and then execute
 code based on which pattern matches. Patterns can be made up of literal values,
 variable names, wildcards, and many other things; [Chapter
-18][ch19-00-patterns]<!-- ignore --> covers all the different kinds of patterns
+19][ch19-00-patterns]<!-- ignore --> covers all the different kinds of patterns
 and what they do. The power of `match` comes from the expressiveness of the
 patterns and the fact that the compiler confirms that all possible cases are
 handled.


### PR DESCRIPTION
Fixed typo so text says the chapter the link points to; see [#274](https://github.com/cognitive-engineering-lab/rust-book/issues/274)