### PR TITLE
Change location of ANCHOR: futures to match Listings 17-10 , 17-12 and 17-13

### DIFF
--- a/listings/ch17-async-await/listing-17-11/src/main.rs
+++ b/listings/ch17-async-await/listing-17-11/src/main.rs
@@ -4,9 +4,9 @@ use std::time::Duration;
 
 fn main() {
     trpl::run(async {
-        let (tx, mut rx) = trpl::channel();
-
         // ANCHOR: futures
+        let (tx, mut rx) = trpl::channel();
+        
         let tx_fut = async {
             let vals = vec![
                 String::from("hi"),


### PR DESCRIPTION
In listings 17-10 , 17-12  and 17-13 , the 

```rust
let (tx, mut rx) = trpl::channel(); 
```

is not left out, but in listing 17-11 it IS.

I propose adding the `tx` and `rx` variables creation to listing 17-11 , so it matches the way the other listings are written.