### PR TITLE
Add anchors to listings 17-31 and 17-32 in order to hide `extern crate trpl;`

### DIFF
--- a/listings/ch17-async-await/listing-17-31/src/main.rs
+++ b/listings/ch17-async-await/listing-17-31/src/main.rs
@@ -1,5 +1,7 @@
 extern crate trpl; // required for mdbook test
 
+// ANCHOR: add-StreamExt-trait
+
 use trpl::StreamExt;
 
 fn main() {
@@ -13,3 +15,5 @@ fn main() {
         }
     });
 }
+
+// ANCHOR_END: add-StreamExt-trait

--- a/listings/ch17-async-await/listing-17-32/src/main.rs
+++ b/listings/ch17-async-await/listing-17-32/src/main.rs
@@ -1,5 +1,7 @@
 extern crate trpl; // required for mdbook test
 
+// ANCHOR: filter-out-except-3-and-5
+
 use trpl::StreamExt;
 
 fn main() {
@@ -16,3 +18,4 @@ fn main() {
         }
     });
 }
+// ANCHOR_END: filter-out-except-3-and-5


### PR DESCRIPTION
Hi! I saw these two listings missing the anchors, so they were showing 

```rust
extern crate trpl; // required for mdbook test
```

Are the anchor names ok? I couldn't find info on any standart naming about them