### PR TITLE
Fix missing code from ch04-02-references-and-borrowing.md

### DIFF
--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -392,6 +392,16 @@ This snippet introduces a new kind of permission, the flow permission @Perm{flow
 
 Unlike the @Perm{read}@Perm{write}@Perm{own} permissions, @Perm{flow} does not change throughout the body of a function. A reference has the @Perm{flow} permission if it's allowed to be used (that is, to *flow*) in a particular expression. For example, let's say we change `first` to a new function `first_or` that includes a `default` parameter:
 
+```rust,ignore
+fn first_or(strings: &Vec<String>, default: &String) -> &String {
+    if strings.is_empty() {
+        default
+    } else {
+        &strings[0]
+    }
+}
+```
+
 This function no longer compiles, because the expressions `&strings[0]` and `default` lack the necessary @Perm{flow} permission to be returned. But why? Rust gives the following error:
 
 ```text


### PR DESCRIPTION
The code for adding the `default` parameter to the example for "Data Must Outlive All Of Its References" sub-section was missing.