### PR TITLE
Clarify formatting of character 'l' in ch08-02-strings.md

### DIFF
--- a/src/ch08-02-strings.md
+++ b/src/ch08-02-strings.md
@@ -132,7 +132,7 @@ If the `push_str` method took ownership of `s2`, we wouldn’t be able to print
 its value on the last line. However, this code works as we’d expect!
 
 The `push` method takes a single character as a parameter and adds it to the
-`String`. Listing 8-17 adds the letter _l_ to a `String` using the `push`
+`String`. Listing 8-17 adds the letter `l` to a `String` using the `push`
 method.
 
 <Listing number="8-17" caption="Adding one character to a `String` value using `push`">


### PR DESCRIPTION
This PR updates a line in `ch08-02-strings.md` where the character `l` was originally italicized as `_l_`. In rendered Markdown, this can be easily confused with a slash '/'.

The update replaces `_l_` with `l` (using backticks), to improve clarity.

Note: This change shares the same intent as commit 2f04f65 by @reinvantveer, which fixed a formatting issue for the same character, albeit with a different proposal ("l" instead of `l`).