### PR TITLE
fix: remove unnecessary `#fn main() {` in chapter 4.2

### DIFF
--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -94,7 +94,6 @@ Observe the difference between `r1` pointing to `x` on the stack, and `r2` point
 You probably won't see the dereference operator very often when you read Rust code. Rust implicitly inserts dereferences and references in certain cases, such as calling a method with the dot operator. For example, this program shows two equivalent ways of calling the [`i32::abs`](https://doc.rust-lang.org/std/primitive.i32.html#method.abs) (absolute value) and [`str::len`](https://doc.rust-lang.org/std/primitive.str.html#method.len) (string length) functions:
 
 ```rust,ignore
-#fn main()  {
 let x: Box<i32> = Box::new(-1);
 let x_abs1 = i32::abs(*x); // explicit dereference
 let x_abs2 = x.abs();      // implicit dereference
@@ -109,7 +108,6 @@ let s = String::from("Hello");
 let s_len1 = str::len(&s); // explicit reference
 let s_len2 = s.len();      // implicit reference
 assert_eq!(s_len1, s_len2);
-#}
 ```
 
 This example shows implicit conversions in three ways:


### PR DESCRIPTION
Not sure if this was intentional. It seems unnecessary and looks confusing.

<img width="1077" height="550" alt="image" src="https://github.com/user-attachments/assets/c7be6de2-ee31-4cd3-9f0f-b7fca3520766" />
